### PR TITLE
Issue #14 parallel backtracking algorithm

### DIFF
--- a/examples/backtracking.jl
+++ b/examples/backtracking.jl
@@ -26,7 +26,7 @@ print(Sudoku.as_text_grid(puzzle))
 #   * up to 8-fold compound rules to simplify backtracking
 #   * up to 57 recursive steps (24 knowns)
 #   * solution cap of 2 to detect a unique solution
-results = Sudoku.backtrack_solve(puzzle,2,81-24,2)
+results = Sudoku.backtrack_solve(puzzle,8,81-24,2)
 if length(results) == 0
     println("Failure: puzzle solution is incomplete")
 elseif length(results) == 1

--- a/examples/backtracking.jl
+++ b/examples/backtracking.jl
@@ -26,7 +26,7 @@ print(Sudoku.as_text_grid(puzzle))
 #   * up to 8-fold compound rules to simplify backtracking
 #   * up to 57 recursive steps (24 knowns)
 #   * solution cap of 2 to detect a unique solution
-results = Sudoku.backtrack_solve(puzzle,8,81-24,2)
+results = Sudoku.backtrack_solve(puzzle,2,81-24,2)
 if length(results) == 0
     println("Failure: puzzle solution is incomplete")
 elseif length(results) == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ end
     SudokuTester.satisfies_puzzle_2()
 end
 
-@testset "Solution helpers" begin
+@testset "Solve helpers" begin
     SudokuTester.solve_example_puzzles()
     SudokuTester.solve_random_puzzles()
 end


### PR DESCRIPTION
Adding a recursive thread spawning approach following the multithreading documentation, I've noticed a 5-10% speedup on some unit tests on a modest laptop.